### PR TITLE
Getting contact information for organizations

### DIFF
--- a/prisma/migrations/20240805140420_init/migration.sql
+++ b/prisma/migrations/20240805140420_init/migration.sql
@@ -3,7 +3,7 @@ CREATE TABLE "Person" (
     "id" TEXT NOT NULL,
     "pureUuid" TEXT NOT NULL,
     "orcid" TEXT,
-    "firstName" TEXT NOT NULL,
+    "firstName" TEXT,
     "lastName" TEXT NOT NULL,
     "portalUrl" TEXT NOT NULL,
     "profilePhotoUrl" TEXT,
@@ -15,15 +15,16 @@ CREATE TABLE "Person" (
 CREATE TABLE "OrganizationMembership" (
     "id" TEXT NOT NULL,
     "pureId" BIGINT NOT NULL,
+    "email" TEXT,
     "startDate" TIMESTAMP(3) NOT NULL,
-    "endDate" TIMESTAMP(3) NOT NULL,
-    "primaryAssociation" BOOLEAN NOT NULL,
-    "jobTitleUri" TEXT NOT NULL,
-    "jobTitle" TEXT NOT NULL,
-    "staffTypeUri" TEXT NOT NULL,
-    "staffType" TEXT NOT NULL,
+    "endDate" TIMESTAMP(3),
+    "primaryAssociation" BOOLEAN,
+    "jobTitleUri" TEXT,
+    "jobTitle" TEXT,
+    "staffTypeUri" TEXT,
+    "staffType" TEXT,
     "personId" TEXT,
-    "organizationId" TEXT NOT NULL,
+    "organizationId" TEXT,
 
     CONSTRAINT "OrganizationMembership_pkey" PRIMARY KEY ("id")
 );
@@ -38,6 +39,18 @@ CREATE TABLE "Organization" (
     "type" TEXT NOT NULL,
 
     CONSTRAINT "Organization_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "OrganizationContact" (
+    "id" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "pureId" BIGINT NOT NULL,
+    "type" TEXT NOT NULL,
+    "typeUri" TEXT NOT NULL,
+    "organizationId" TEXT,
+
+    CONSTRAINT "OrganizationContact_pkey" PRIMARY KEY ("id")
 );
 
 -- CreateTable
@@ -59,6 +72,9 @@ CREATE UNIQUE INDEX "OrganizationMembership_pureId_key" ON "OrganizationMembersh
 CREATE UNIQUE INDEX "Organization_pureUuid_key" ON "Organization"("pureUuid");
 
 -- CreateIndex
+CREATE UNIQUE INDEX "OrganizationContact_pureId_key" ON "OrganizationContact"("pureId");
+
+-- CreateIndex
 CREATE UNIQUE INDEX "_OrganizationRelation_AB_unique" ON "_OrganizationRelation"("A", "B");
 
 -- CreateIndex
@@ -68,7 +84,10 @@ CREATE INDEX "_OrganizationRelation_B_index" ON "_OrganizationRelation"("B");
 ALTER TABLE "OrganizationMembership" ADD CONSTRAINT "OrganizationMembership_personId_fkey" FOREIGN KEY ("personId") REFERENCES "Person"("id") ON DELETE SET NULL ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "OrganizationMembership" ADD CONSTRAINT "OrganizationMembership_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "OrganizationMembership" ADD CONSTRAINT "OrganizationMembership_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "OrganizationContact" ADD CONSTRAINT "OrganizationContact_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE SET NULL ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "_OrganizationRelation" ADD CONSTRAINT "_OrganizationRelation_A_fkey" FOREIGN KEY ("A") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -53,6 +53,20 @@ model Organization {
   typeUri    String
   type       String
 
+  contact OrganizationContact[]
+
   parents  Organization[] @relation("OrganizationRelation")
   children Organization[] @relation("OrganizationRelation")
+}
+
+model OrganizationContact {
+  id String @id @default(cuid())
+
+  email   String
+  pureId  String
+  type    String
+  typeUri String
+
+  organization   Organization? @relation(fields: [organizationId], references: [id])
+  organizationId String?
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -63,7 +63,7 @@ model OrganizationContact {
   id String @id @default(cuid())
 
   email   String
-  pureId  String
+  pureId  BigInt @unique
   type    String
   typeUri String
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,45 +1,14 @@
 import { PrismaClient } from "@prisma/client"
-import { getOrganizations } from "./utils/getOrganizations"
 import { createPersons } from "./utils/createPersons"
+import { createOrganizations } from "./utils/createOrganizations"
 
 const db = new PrismaClient()
 
 async function main() {
   // Get all the TU/e Organizations
   const baseUrl = "https://pure.tue.nl/ws/api/"
-  const organizations = await getOrganizations({ baseUrl })
 
-  const orgInputData = organizations.map((o) => {
-    return {
-      pureUuid: o.uuid,
-      name: o.name.en_GB as string,
-      shortName: o.nameVariants.find((n) => n.type.term.en_GB === "Short name")
-        ?.value?.en_GB as string,
-      typeUri: o.type.uri,
-      type: o.type.term.en_GB as string,
-    }
-  })
-
-  const createdOrgs = await db.organization.createMany({
-    data: orgInputData,
-    skipDuplicates: true,
-  })
-  if (createdOrgs.count > 0) {
-    console.log(`✅ Created ${createdOrgs.count} new organizations`)
-  } else {
-    console.log("⏩ No new organizations created")
-  }
-
-  // Connecting organizations with each other
-  organizations.forEach(async (o) => {
-    await db.organization.update({
-      where: { pureUuid: o.uuid },
-      data: {
-        parents: { connect: o.parents?.map((p) => ({ pureUuid: p.uuid })) },
-      },
-    })
-  })
-
+  await createOrganizations({ db, baseUrl })
   await createPersons({ db, baseUrl })
 }
 

--- a/src/utils/createOrganizations.ts
+++ b/src/utils/createOrganizations.ts
@@ -1,0 +1,46 @@
+import type { PrismaClient } from "@prisma/client/extension"
+import { getOrganizations } from "./getOrganizations"
+import type { Prisma } from "@prisma/client"
+
+type CreateOrganizationsProps = {
+  db: PrismaClient
+  baseUrl: string
+}
+
+export async function createOrganizations({
+  db,
+  baseUrl,
+}: CreateOrganizationsProps) {
+  const organizations = await getOrganizations({ baseUrl })
+
+  const orgInputData = organizations.map((o) => {
+    return {
+      pureUuid: o.uuid,
+      name: o.name.en_GB as string,
+      shortName: o.nameVariants.find((n) => n.type.term.en_GB === "Short name")
+        ?.value?.en_GB as string,
+      typeUri: o.type.uri,
+      type: o.type.term.en_GB as string,
+    }
+  }) as Prisma.OrganizationCreateManyInput[]
+
+  const createdOrgs = await db.organization.createMany({
+    data: orgInputData,
+    skipDuplicates: true,
+  })
+  if (createdOrgs.count > 0) {
+    console.log(`✅ Created ${createdOrgs.count} new organizations`)
+  } else {
+    console.log("⏩ No new organizations created")
+  }
+
+  // Connecting organizations with each other
+  organizations.forEach(async (o) => {
+    await db.organization.update({
+      where: { pureUuid: o.uuid },
+      data: {
+        parents: { connect: o.parents?.map((p) => ({ pureUuid: p.uuid })) },
+      },
+    })
+  })
+}


### PR DESCRIPTION
This PR adds a new Prisma schema and sourcing script to get data about organization contact info. (e.g., secretariat and team leader emails for groups, where available)

Fixes #1 